### PR TITLE
feat(report): Bold the shift report preamble

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -29,7 +29,7 @@ const create = async(userId, view) => {
   let user_report = view.state.values.notes_block.report_text.value;
 
   let lightwood_post = `<@${process.env.ANASTASIA_LIGHTWOOD_SLACK_ID}> post`;
-  let run_notes_preamble = `(${user_real_name} - shift report):`;
+  let run_notes_preamble = `'''(${user_real_name} - shift report)''':`;
   let report_msg = `${lightwood_post} ${run_notes_preamble} ${user_report}`;
 
   await sendReport({user_id: userId, report: report_msg});


### PR DESCRIPTION
To make it stand out more in the run notes.  NB: this has to be Wikimedia bolding (via three single quotes), not Slack Mrkdwn bolding using asterisks.

Has been deployed to `bao` for testing.